### PR TITLE
fix: send data correctly when keepalive is enabled

### DIFF
--- a/src/__tests__/axios.spec.ts
+++ b/src/__tests__/axios.spec.ts
@@ -3,7 +3,7 @@ import { CookieJar } from 'tough-cookie';
 import axios from 'axios';
 
 import { HttpCookieAgent } from '../';
-import { createTestServer } from './helpers';
+import { createTestServer, readStream } from './helpers';
 
 test('should set cookies to CookieJar from Set-Cookie header', async (t) => {
   const jar = new CookieJar();
@@ -180,4 +180,31 @@ test('should emit error when CookieJar#setCookie throws error.', async (t) => {
   });
 
   t.plan(1);
+});
+
+test('should send post data when keepalive is enabled', async (t) => {
+  const times = 2;
+
+  const jar = new CookieJar();
+  const agent = new HttpCookieAgent({ jar, keepAlive: true });
+
+  const { port } = await createTestServer(
+    Array.from({ length: times }, (_, idx) => {
+      return async (req, res) => {
+        t.is(await readStream(req), `{ "index": "${idx}" }`);
+        t.is(req.headers['cookie'], 'key=expected');
+        res.end();
+      };
+    }),
+  );
+
+  await jar.setCookie('key=expected', `http://localhost:${port}`);
+
+  for (let idx = 0; idx < times; idx++) {
+    await axios.post(`http://localhost:${port}`, `{ "index": "${idx}" }`, {
+      httpAgent: agent,
+    });
+  }
+
+  t.plan(times * 2);
 });

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -2,6 +2,7 @@ import http from 'http';
 import httpProxy from 'http-proxy';
 import { promisify } from 'util';
 import { URL } from 'url';
+import { Readable } from 'stream';
 
 export async function createTestServer(
   stories: http.RequestListener[],
@@ -23,6 +24,11 @@ export async function createTestServer(
     if (stories.length === 0) {
       server.close();
     }
+  });
+
+  server.on('clientError', (err, socket) => {
+    console.error(err);
+    socket.end();
   });
 
   return {
@@ -66,4 +72,12 @@ export async function createTestServerWithProxy(
     port,
     proxyPort: serverInfo.port,
   };
+}
+
+export async function readStream(stream: Readable): Promise<string> {
+  let data = '';
+  for await (const chunk of stream) {
+    data += chunk;
+  }
+  return data;
 }

--- a/src/__tests__/http.spec.ts
+++ b/src/__tests__/http.spec.ts
@@ -16,7 +16,6 @@ export function request(url: string, options: http.RequestOptions) {
     });
     req.on('error', (err) => reject(err));
   });
-  req.end();
 
   return { req, promise };
 }
@@ -32,10 +31,11 @@ test('should set cookies to CookieJar from Set-Cookie header', async (t) => {
     },
   ]);
 
-  const { promise } = request(`http://localhost:${port}`, {
+  const { promise, req } = request(`http://localhost:${port}`, {
     method: 'GET',
     agent,
   });
+  req.end();
   await promise;
 
   const cookies = await jar.getCookies(`http://localhost:${port}`);
@@ -56,10 +56,11 @@ test('should set cookies to CookieJar from multiple Set-Cookie headers', async (
     },
   ]);
 
-  const { promise } = request(`http://localhost:${port}`, {
+  const { promise, req } = request(`http://localhost:${port}`, {
     method: 'GET',
     agent,
   });
+  req.end();
   await promise;
 
   const cookies = await jar.getCookies(`http://localhost:${port}`);
@@ -83,10 +84,11 @@ test('should send cookies from CookieJar', async (t) => {
 
   await jar.setCookie('key=value', `http://localhost:${port}`);
 
-  const { promise } = request(`http://localhost:${port}`, {
+  const { promise, req } = request(`http://localhost:${port}`, {
     method: 'GET',
     agent,
   });
+  req.end();
   await promise;
 
   t.plan(1);
@@ -105,10 +107,11 @@ test('should send cookies from CookieJar when value is url-encoded', async (t) =
 
   await jar.setCookie('key=hello%20world', `http://localhost:${port}`);
 
-  const { promise } = request(`http://localhost:${port}`, {
+  const { promise, req } = request(`http://localhost:${port}`, {
     method: 'GET',
     agent,
   });
+  req.end();
   await promise;
 
   t.plan(1);
@@ -127,11 +130,12 @@ test('should send cookies from both a request options and CookieJar', async (t) 
 
   await jar.setCookie('key1=value1', `http://localhost:${port}`);
 
-  const { promise } = request(`http://localhost:${port}`, {
+  const { promise, req } = request(`http://localhost:${port}`, {
     method: 'GET',
     agent,
     headers: { Cookie: 'key2=value2' },
   });
+  req.end();
   await promise;
 
   t.plan(1);
@@ -150,11 +154,12 @@ test('should send cookies from a request options when the key is duplicated in b
 
   await jar.setCookie('key=notexpected', `http://localhost:${port}`);
 
-  const { promise } = request(`http://localhost:${port}`, {
+  const { promise, req } = request(`http://localhost:${port}`, {
     method: 'GET',
     agent,
     headers: { Cookie: 'key=expected' },
   });
+  req.end();
   await promise;
 
   t.plan(1);
@@ -174,10 +179,11 @@ test('should emit error when CookieJar#getCookies throws error.', async (t) => {
     },
   ]);
 
-  const { promise } = request(`http://localhost:${port}`, {
+  const { promise, req } = request(`http://localhost:${port}`, {
     method: 'GET',
     agent,
   });
+  req.end();
   await t.throwsAsync(() => promise);
 
   t.plan(1);
@@ -197,10 +203,11 @@ test('should emit error when CookieJar#setCookie throws error.', async (t) => {
     },
   ]);
 
-  const { promise } = request(`http://localhost:${port}`, {
+  const { promise, req } = request(`http://localhost:${port}`, {
     method: 'GET',
     agent,
   });
+  req.end();
   await t.throwsAsync(() => promise);
 
   t.plan(1);
@@ -225,17 +232,19 @@ test('should send cookies even when target is same host but different port', asy
   ]);
 
   {
-    const { promise } = request(`http://localhost:${firstServerPort}`, {
+    const { promise, req } = request(`http://localhost:${firstServerPort}`, {
       method: 'GET',
       agent,
     });
+    req.end();
     await promise;
   }
   {
-    const { promise } = request(`http://localhost:${secondServerPort}`, {
+    const { promise, req } = request(`http://localhost:${secondServerPort}`, {
       method: 'GET',
       agent,
     });
+    req.end();
     await promise;
   }
 

--- a/src/__tests__/needle.spec.ts
+++ b/src/__tests__/needle.spec.ts
@@ -3,7 +3,7 @@ import { CookieJar } from 'tough-cookie';
 import needle from 'needle';
 
 import { HttpCookieAgent } from '../';
-import { createTestServer } from './helpers';
+import { createTestServer, readStream } from './helpers';
 
 test('should set cookies to CookieJar from Set-Cookie header', async (t) => {
   const jar = new CookieJar();
@@ -181,4 +181,31 @@ test('should emit error when CookieJar#setCookie throws error.', async (t) => {
   });
 
   t.plan(1);
+});
+
+test('should send post data when keepalive is enabled', async (t) => {
+  const times = 2;
+
+  const jar = new CookieJar();
+  const agent = new HttpCookieAgent({ jar, keepAlive: true });
+
+  const { port } = await createTestServer(
+    Array.from({ length: times }, (_, idx) => {
+      return async (req, res) => {
+        t.is(await readStream(req), `{ "index": "${idx}" }`);
+        t.is(req.headers['cookie'], 'key=expected');
+        res.end();
+      };
+    }),
+  );
+
+  await jar.setCookie('key=expected', `http://localhost:${port}`);
+
+  for (let idx = 0; idx < times; idx++) {
+    await needle('post', `http://localhost:${port}`, `{ "index": "${idx}" }`, {
+      agent,
+    });
+  }
+
+  t.plan(times * 2);
 });

--- a/src/__tests__/node-fetch.spec.ts
+++ b/src/__tests__/node-fetch.spec.ts
@@ -3,7 +3,7 @@ import { CookieJar } from 'tough-cookie';
 import fetch from 'node-fetch';
 
 import { HttpCookieAgent } from '../';
-import { createTestServer } from './helpers';
+import { createTestServer, readStream } from './helpers';
 
 test('should set cookies to CookieJar from Set-Cookie header', async (t) => {
   const jar = new CookieJar();
@@ -180,4 +180,33 @@ test('should emit error when CookieJar#setCookie throws error.', async (t) => {
   });
 
   t.plan(1);
+});
+
+test('should send post data when keepalive is enabled', async (t) => {
+  const times = 2;
+
+  const jar = new CookieJar();
+  const agent = new HttpCookieAgent({ jar, keepAlive: true });
+
+  const { port } = await createTestServer(
+    Array.from({ length: times }, (_, idx) => {
+      return async (req, res) => {
+        t.is(await readStream(req), `{ "index": "${idx}" }`);
+        t.is(req.headers['cookie'], 'key=expected');
+        res.end();
+      };
+    }),
+  );
+
+  await jar.setCookie('key=expected', `http://localhost:${port}`);
+
+  for (let idx = 0; idx < times; idx++) {
+    await fetch(`http://localhost:${port}`, {
+      method: 'POST',
+      body: `{ "index": "${idx}" }`,
+      agent,
+    });
+  }
+
+  t.plan(times * 2);
 });

--- a/src/__tests__/phin.spec.ts
+++ b/src/__tests__/phin.spec.ts
@@ -3,7 +3,7 @@ import { CookieJar } from 'tough-cookie';
 import phin from 'phin';
 
 import { HttpCookieAgent } from '../';
-import { createTestServer } from './helpers';
+import { createTestServer, readStream } from './helpers';
 
 test('should set cookies to CookieJar from Set-Cookie header', async (t) => {
   const jar = new CookieJar();
@@ -189,4 +189,34 @@ test('should emit error when CookieJar#setCookie throws error.', async (t) => {
   });
 
   t.plan(1);
+});
+
+test('should send post data when keepalive is enabled', async (t) => {
+  const times = 2;
+
+  const jar = new CookieJar();
+  const agent = new HttpCookieAgent({ jar, keepAlive: true });
+
+  const { port } = await createTestServer(
+    Array.from({ length: times }, (_, idx) => {
+      return async (req, res) => {
+        t.is(await readStream(req), `{ "index": "${idx}" }`);
+        t.is(req.headers['cookie'], 'key=expected');
+        res.end();
+      };
+    }),
+  );
+
+  await jar.setCookie('key=expected', `http://localhost:${port}`);
+
+  for (let idx = 0; idx < times; idx++) {
+    await phin({
+      method: 'POST',
+      data: `{ "index": "${idx}" }`,
+      url: `http://localhost:${port}`,
+      core: { agent },
+    });
+  }
+
+  t.plan(times * 2);
 });

--- a/src/__tests__/request.spec.ts
+++ b/src/__tests__/request.spec.ts
@@ -4,7 +4,7 @@ import { CookieJar } from 'tough-cookie';
 import request from 'request';
 
 import { HttpCookieAgent } from '../';
-import { createTestServer } from './helpers';
+import { createTestServer, readStream } from './helpers';
 
 test('should set cookies to CookieJar from Set-Cookie header', async (t) => {
   const jar = new CookieJar();
@@ -189,4 +189,34 @@ test('should emit error when CookieJar#setCookie throws error.', async (t) => {
   });
 
   t.plan(1);
+});
+
+test('should send post data when keepalive is enabled', async (t) => {
+  const times = 2;
+
+  const jar = new CookieJar();
+  const agent = new HttpCookieAgent({ jar, keepAlive: true });
+
+  const { port } = await createTestServer(
+    Array.from({ length: times }, (_, idx) => {
+      return async (req, res) => {
+        t.is(await readStream(req), `{ "index": "${idx}" }`);
+        t.is(req.headers['cookie'], 'key=expected');
+        res.end();
+      };
+    }),
+  );
+
+  await jar.setCookie('key=expected', `http://localhost:${port}`);
+
+  for (let idx = 0; idx < times; idx++) {
+    await promisify(request)({
+      agent,
+      method: 'POST',
+      body: `{ "index": "${idx}" }`,
+      url: `http://localhost:${port}`,
+    });
+  }
+
+  t.plan(times * 2);
 });

--- a/src/__tests__/superagent.spec.ts
+++ b/src/__tests__/superagent.spec.ts
@@ -3,7 +3,7 @@ import { CookieJar } from 'tough-cookie';
 import superagent from 'superagent';
 
 import { HttpCookieAgent } from '../';
-import { createTestServer } from './helpers';
+import { createTestServer, readStream } from './helpers';
 
 test('should set cookies to CookieJar from Set-Cookie header', async (t) => {
   const jar = new CookieJar();
@@ -162,4 +162,29 @@ test('should emit error when CookieJar#setCookie throws error.', async (t) => {
   });
 
   t.plan(1);
+});
+
+test('should send post data when keepalive is enabled', async (t) => {
+  const times = 2;
+
+  const jar = new CookieJar();
+  const agent = new HttpCookieAgent({ jar, keepAlive: true });
+
+  const { port } = await createTestServer(
+    Array.from({ length: times }, (_, idx) => {
+      return async (req, res) => {
+        t.is(await readStream(req), `{ "index": "${idx}" }`);
+        t.is(req.headers['cookie'], 'key=expected');
+        res.end();
+      };
+    }),
+  );
+
+  await jar.setCookie('key=expected', `http://localhost:${port}`);
+
+  for (let idx = 0; idx < times; idx++) {
+    await superagent.post(`http://localhost:${port}`).send(`{ "index": "${idx}" }`).agent(agent);
+  }
+
+  t.plan(times * 2);
 });

--- a/src/__tests__/urllib.spec.ts
+++ b/src/__tests__/urllib.spec.ts
@@ -3,7 +3,7 @@ import { CookieJar } from 'tough-cookie';
 import urllib from 'urllib';
 
 import { HttpCookieAgent } from '../';
-import { createTestServer } from './helpers';
+import { createTestServer, readStream } from './helpers';
 
 test('should set cookies to CookieJar from Set-Cookie header', async (t) => {
   const jar = new CookieJar();
@@ -181,4 +181,33 @@ test('should emit error when CookieJar#setCookie throws error.', async (t) => {
   });
 
   t.plan(1);
+});
+
+test('should send post data when keepalive is enabled', async (t) => {
+  const times = 2;
+
+  const jar = new CookieJar();
+  const agent = new HttpCookieAgent({ jar, keepAlive: true });
+
+  const { port } = await createTestServer(
+    Array.from({ length: times }, (_, idx) => {
+      return async (req, res) => {
+        t.is(await readStream(req), `{ "index": "${idx}" }`);
+        t.is(req.headers['cookie'], 'key=expected');
+        res.end();
+      };
+    }),
+  );
+
+  await jar.setCookie('key=expected', `http://localhost:${port}`);
+
+  for (let idx = 0; idx < times; idx++) {
+    await urllib.request(`http://localhost:${port}`, {
+      agent,
+      method: 'POST',
+      data: `{ "index": "${idx}" }`,
+    });
+  }
+
+  t.plan(times * 2);
 });

--- a/src/__tests__/wreck.spec.ts
+++ b/src/__tests__/wreck.spec.ts
@@ -3,7 +3,7 @@ import { CookieJar } from 'tough-cookie';
 import Wreck from '@hapi/wreck';
 
 import { HttpCookieAgent } from '../';
-import { createTestServer } from './helpers';
+import { createTestServer, readStream } from './helpers';
 
 test('should set cookies to CookieJar from Set-Cookie header', async (t) => {
   const jar = new CookieJar();
@@ -181,4 +181,32 @@ test('should emit error when CookieJar#setCookie throws error.', async (t) => {
   });
 
   t.plan(1);
+});
+
+test('should send post data when keepalive is enabled', async (t) => {
+  const times = 2;
+
+  const jar = new CookieJar();
+  const agent = new HttpCookieAgent({ jar, keepAlive: true });
+
+  const { port } = await createTestServer(
+    Array.from({ length: times }, (_, idx) => {
+      return async (req, res) => {
+        t.is(await readStream(req), `{ "index": "${idx}" }`);
+        t.is(req.headers['cookie'], 'key=expected');
+        res.end();
+      };
+    }),
+  );
+
+  await jar.setCookie('key=expected', `http://localhost:${port}`);
+
+  for (let idx = 0; idx < times; idx++) {
+    await Wreck.post(`http://localhost:${port}`, {
+      agent,
+      payload: `{ "index": "${idx}" }`,
+    });
+  }
+
+  t.plan(times * 2);
 });

--- a/src/create_cookie_agent.ts
+++ b/src/create_cookie_agent.ts
@@ -104,6 +104,7 @@ export function createCookieAgent<
       req._header = null;
       req.setHeader('Cookie', cookieHeader);
       req._implicitHeader();
+      req._headerSent = alreadyHeaderSent;
 
       if (alreadyHeaderSent !== true) {
         return;


### PR DESCRIPTION
closed https://github.com/3846masa/http-cookie-agent/issues/65