### PR TITLE
feat: drop Node.js v12 support

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ['12', '14', '16']
+        node: ["14", "16", "18"]
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
       - name: Setup Node.js
         uses: actions/setup-node@56337c425554a6be30cdef71bf441f15be286854 # tag=v3.1.1
         with:
           node-version: ${{ matrix.node }}
-          cache: 'yarn'
+          cache: "yarn"
       - run: yarn install --frozen-lockfile
       - run: yarn test
   release:
@@ -33,8 +33,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@56337c425554a6be30cdef71bf441f15be286854 # tag=v3.1.1
         with:
-          node-version: '14'
-          cache: 'yarn'
+          node-version: "16"
+          cache: "yarn"
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - name: Release

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@semantic-release/git": "9.0.1",
     "@types/http-proxy": "1.17.8",
     "@types/needle": "2.5.3",
-    "@types/node": "12.20.50",
+    "@types/node": "14.18.16",
     "@types/node-fetch": "2.6.1",
     "@types/request": "2.48.8",
     "@types/superagent": "4.1.15",
@@ -78,7 +78,7 @@
     "urllib"
   ],
   "engines": {
-    "node": ">=12.19.0 <13.0.0 || >=14.5.0"
+    "node": ">=14.18.0 <15.0.0 || >=16.0.0"
   },
   "ava": {
     "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -520,10 +520,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.1.tgz#0611b37db4246c937feef529ddcc018cf8e35708"
   integrity sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==
 
-"@types/node@12.20.50":
-  version "12.20.50"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.50.tgz#14ba5198f1754ffd0472a2f84ab433b45ee0b65e"
-  integrity sha512-+9axpWx2b2JCVovr7Ilgt96uc6C1zBKOQMpGtRbWT9IoR/8ue32GGMfGA4woP8QyP2gBs6GQWEVM3tCybGCxDA==
+"@types/node@14.18.16":
+  version "14.18.16"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.16.tgz#878f670ba3f00482bf859b6550b6010610fc54b5"
+  integrity sha512-X3bUMdK/VmvrWdoTkz+VCn6nwKwrKCFTHtqwBIaQJNx4RUIBBUFXM00bqPz/DsDd+Icjmzm6/tyYZzeGVqb6/Q==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION
BREAKING CHANGE: drop Node.js v12 support, please use v14.18.0 or above