### PR TITLE
Update Peer Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   "peerDependencies": {
     "deasync": "^0.1.26",
     "tough-cookie": "^4.0.0",
-    "undici": "^5.11.0"
+    "undici": "^6.2.1"
   },
   "peerDependenciesMeta": {
     "deasync": {


### PR DESCRIPTION
### Context

The peer dependency for `undici` also needs to be updated to `6.x.x` or else npm will refuse to install by default.

cc/ @3846masa