### PR TITLE
fix: add undici v6 to peerdeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
   "peerDependencies": {
     "deasync": "^0.1.26",
     "tough-cookie": "^4.0.0",
-    "undici": "^5.11.0"
+    "undici": "^5.11.0 || ^6.0.0"
   },
   "peerDependenciesMeta": {
     "deasync": {


### PR DESCRIPTION
close https://github.com/3846masa/http-cookie-agent/pull/730