### PR TITLE
fix: fix http/index.d.ts types

### DIFF
--- a/http/index.d.ts
+++ b/http/index.d.ts
@@ -1,5 +1,5 @@
-import type { Agent as HttpAgent, AgentOptions as HttpAgentOptions } from 'node:http';
-import type { Agent as HttpsAgent, AgentOptions as HttpsAgentOptions } from 'node:https';
+import type * as http from 'node:http';
+import type * as https from 'node:https';
 
 import type { CookieJar } from 'tough-cookie';
 
@@ -11,19 +11,19 @@ export type CookieAgentOptions = {
   cookies?: CookieOptions | undefined;
 };
 
-type CookieAgent<BaseAgent extends HttpAgent> = BaseAgent;
+type CookieAgent<BaseAgent extends http.Agent> = BaseAgent;
 
-type WithCookieAgentOptions<T> = T extends HttpAgentOptions ? T & CookieAgentOptions : T;
+type WithCookieAgentOptions<T> = T extends http.AgentOptions ? T & CookieAgentOptions : T;
 type ConstructorParams<Params extends unknown[]> = {
   [Index in keyof Params]: WithCookieAgentOptions<Params[Index]>;
 };
 
-export function createCookieAgent<BaseAgent extends HttpAgent = HttpAgent, Params extends unknown[] = unknown[]>(
+export function createCookieAgent<BaseAgent extends http.Agent = http.Agent, Params extends unknown[] = unknown[]>(
   BaseAgent: new (...rest: Params) => BaseAgent,
 ): new (...rest: ConstructorParams<Params>) => CookieAgent<BaseAgent>;
 
-export const HttpCookieAgent: new (options: HttpAgentOptions & CookieAgentOptions) => CookieAgent<HttpAgent>;
-export const HttpsCookieAgent: new (options: HttpsAgentOptions & CookieAgentOptions) => CookieAgent<HttpsAgent>;
+export const HttpCookieAgent: new (options: http.AgentOptions & CookieAgentOptions) => CookieAgent<http.Agent>;
+export const HttpsCookieAgent: new (options: https.AgentOptions & CookieAgentOptions) => CookieAgent<https.Agent>;
 export const MixedCookieAgent: new (
-  options: HttpAgentOptions & HttpsAgentOptions & CookieAgentOptions,
-) => CookieAgent<HttpsAgent>;
+  options: http.AgentOptions & https.AgentOptions & CookieAgentOptions,
+) => CookieAgent<https.Agent>;

--- a/http/index.d.ts
+++ b/http/index.d.ts
@@ -1,5 +1,5 @@
-import type http from 'node:http';
-import type https from 'node:https';
+import type { Agent as HttpAgent, AgentOptions as HttpAgentOptions } from 'node:http';
+import type { Agent as HttpsAgent, AgentOptions as HttpsAgentOptions } from 'node:https';
 
 import type { CookieJar } from 'tough-cookie';
 
@@ -11,19 +11,19 @@ export type CookieAgentOptions = {
   cookies?: CookieOptions | undefined;
 };
 
-type CookieAgent<BaseAgent extends http.Agent> = BaseAgent;
+type CookieAgent<BaseAgent extends HttpAgent> = BaseAgent;
 
-type WithCookieAgentOptions<T> = T extends http.AgentOptions ? T & CookieAgentOptions : T;
-type ConstructorParams<Params> = {
+type WithCookieAgentOptions<T> = T extends HttpAgentOptions ? T & CookieAgentOptions : T;
+type ConstructorParams<Params extends unknown[]> = {
   [Index in keyof Params]: WithCookieAgentOptions<Params[Index]>;
-} & { length: Params['length'] };
+};
 
-export function createCookieAgent<BaseAgent extends http.Agent = http.Agent, Params extends unknown[] = unknown[]>(
+export function createCookieAgent<BaseAgent extends HttpAgent = HttpAgent, Params extends unknown[] = unknown[]>(
   BaseAgent: new (...rest: Params) => BaseAgent,
 ): new (...rest: ConstructorParams<Params>) => CookieAgent<BaseAgent>;
 
-export const HttpCookieAgent: new (options: http.AgentOptions & CookieAgentOptions) => CookieAgent<http.Agent>;
-export const HttpsCookieAgent: new (options: https.AgentOptions & CookieAgentOptions) => CookieAgent<https.Agent>;
+export const HttpCookieAgent: new (options: HttpAgentOptions & CookieAgentOptions) => CookieAgent<HttpAgent>;
+export const HttpsCookieAgent: new (options: HttpsAgentOptions & CookieAgentOptions) => CookieAgent<HttpsAgent>;
 export const MixedCookieAgent: new (
-  options: http.AgentOptions & https.AgentOptions & CookieAgentOptions,
-) => CookieAgent<https.Agent>;
+  options: HttpAgentOptions & HttpsAgentOptions & CookieAgentOptions,
+) => CookieAgent<HttpsAgent>;

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "lint:eslint": "eslint --max-warnings 0 .",
     "lint:prettier": "prettier --check .",
     "lint:tsc": "tsc --noEmit",
+    "lint:tsc:types": "tsc --noEmit http/index.d.ts",
     "semantic-release": "semantic-release",
     "test": "NODE_OPTIONS=\"--experimental-vm-modules\" jest"
   },

--- a/package.json
+++ b/package.json
@@ -49,10 +49,10 @@
     "format:eslint": "eslint --fix .",
     "format:prettier": "prettier --write .",
     "lint": "pnpm run \"/^lint:.*/\"",
+    "lint:dts": "tsc --noEmit http/*.d.ts undici/*.d.ts",
     "lint:eslint": "eslint --max-warnings 0 .",
     "lint:prettier": "prettier --check .",
     "lint:tsc": "tsc --noEmit",
-    "lint:tsc:types": "tsc --noEmit http/index.d.ts",
     "semantic-release": "semantic-release",
     "test": "NODE_OPTIONS=\"--experimental-vm-modules\" jest"
   },

--- a/src/http/create_cookie_agent.ts
+++ b/src/http/create_cookie_agent.ts
@@ -39,7 +39,7 @@ export function createCookieAgent<BaseAgent extends http.Agent = http.Agent, Par
   type WithCookieAgentOptions<T> = T extends http.AgentOptions ? T & CookieAgentOptions : T;
   type ConstructorParams = {
     [Index in keyof Params]: WithCookieAgentOptions<Params[Index]>;
-  } & { length: Params['length'] };
+  };
 
   // @ts-expect-error -- BaseAgentClass is type definition.
   class CookieAgent extends BaseAgentClass {


### PR DESCRIPTION
This PR aims to improve the handcrafted typings in `index.d.ts` in order to allow projects that depend on this to have `skipLibCheck` set to `false`.

Since `skipLibCheck` is true in `tsconfig.json` (through `extends` config), `index.d.ts` is not compiled with tsc (see https://github.com/microsoft/TypeScript/issues/30511).

I added a separate step (`lint:tsc:types`) that compiles this file specifically and also fixed the issues typescript complained about.

```
http/index.d.ts:1:13 - error TS1192: Module '"node:http"' has no default export.
1 import type http from 'node:http';

http/index.d.ts:2:13 - error TS1192: Module '"node:https"' has no default export.
2 import type https from 'node:https';

http/index.d.ts:19:15 - error TS2536: Type '"length"' cannot be used to index type 'Params'.
19 } & { length: Params['length'] };
```
