### PR TITLE
chore(npm): update dependency tough-cookie to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "semantic-release": "24.2.7",
     "semver": "7.7.2",
     "superagent": "10.2.3",
-    "tough-cookie": "5.1.2",
+    "tough-cookie": "6.0.0",
     "typescript": "5.9.2",
     "undici": "7.10.0",
     "undici__v6": "npm:undici@6.21.3",
@@ -98,7 +98,7 @@
     "vitest": "3.2.4"
   },
   "peerDependencies": {
-    "tough-cookie": "^4.0.0 || ^5.0.0",
+    "tough-cookie": "^4.0.0 || ^5.0.0 || ^6.0.0",
     "undici": "^7.0.0"
   },
   "peerDependenciesMeta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,8 +108,8 @@ importers:
         specifier: 10.2.3
         version: 10.2.3
       tough-cookie:
-        specifier: 5.1.2
-        version: 5.1.2
+        specifier: 6.0.0
+        version: 6.0.0
       typescript:
         specifier: 5.9.2
         version: 5.9.2
@@ -3868,11 +3868,11 @@ packages:
     resolution: {integrity: sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==}
     engines: {node: '>=14.0.0'}
 
-  tldts-core@6.1.46:
-    resolution: {integrity: sha512-zA3ai/j4aFcmbqTvTONkSBuWs0Q4X4tJxa0gV9sp6kDbq5dAhQDSg0WUkReEm0fBAKAGNj+wPKCCsR8MYOYmwA==}
+  tldts-core@7.0.12:
+    resolution: {integrity: sha512-3K76aXywJFduGRsOYoY5JzINLs/WMlOkeDwPL+8OCPq2Rh39gkSDtWAxdJQlWjpun/xF/LHf29yqCi6VC/rHDA==}
 
-  tldts@6.1.46:
-    resolution: {integrity: sha512-fw81lXV2CijkNrZAZvee7wegs+EOlTyIuVl/z4q6OUzZHQ1jGL2xQzKXq9geYf/1tzo9LZQLrkcko2m8HLh+rg==}
+  tldts@7.0.12:
+    resolution: {integrity: sha512-M9ZQBPp6FyqhMcl233vHYyYRkxXOA1SKGlnq13S0mJdUhRSwr2w6I8rlchPL73wBwRlyIZpFvpu2VcdSMWLYXw==}
     hasBin: true
 
   to-regex-range@5.0.1:
@@ -3883,8 +3883,8 @@ packages:
     resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
     engines: {node: '>=0.8'}
 
-  tough-cookie@5.1.2:
-    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+  tough-cookie@6.0.0:
+    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
     engines: {node: '>=16'}
 
   traverse@0.6.8:
@@ -8261,11 +8261,11 @@ snapshots:
 
   tinyspy@4.0.3: {}
 
-  tldts-core@6.1.46: {}
+  tldts-core@7.0.12: {}
 
-  tldts@6.1.46:
+  tldts@7.0.12:
     dependencies:
-      tldts-core: 6.1.46
+      tldts-core: 7.0.12
 
   to-regex-range@5.0.1:
     dependencies:
@@ -8276,9 +8276,9 @@ snapshots:
       psl: 1.9.0
       punycode: 2.3.1
 
-  tough-cookie@5.1.2:
+  tough-cookie@6.0.0:
     dependencies:
-      tldts: 6.1.46
+      tldts: 7.0.12
 
   traverse@0.6.8: {}
 


### PR DESCRIPTION
Updates tough-cookie to v6.0.0. 
Expands peer dependency range for tough-cookie to include v6.